### PR TITLE
Use `limit_maximum` instead of magic number

### DIFF
--- a/gcexport.py
+++ b/gcexport.py
@@ -98,7 +98,7 @@ username = args.username if args.username else raw_input('Username: ')
 password = args.password if args.password else getpass()
 
 # Maximum number of activities you can request at once.  Set and enforced by Garmin.
-limit_maximum = 100
+limit_maximum = 19
 
 hostname_url = http_req('http://connect.garmin.com/gauth/hostname')
 # print hostname_url
@@ -271,9 +271,10 @@ total_downloaded = 0
 
 # This while loop will download data from the server in multiple chunks, if necessary.
 while total_downloaded < total_to_download:
-	# Maximum of 100... 400 return status if over 100.  So download 100 or whatever remains if less than 100.
-	if total_to_download - total_downloaded > 100:
-		num_to_download = 100
+	# Maximum chunk size 'limit_maximum' ... 400 return status if over maximum.  So download maximum or whatever remains if less than maximum.
+	# As of 2018-03-06 I get return status 500 if over maximum
+	if total_to_download - total_downloaded > limit_maximum:
+		num_to_download = limit_maximum
 	else:
 		num_to_download = total_to_download - total_downloaded
 


### PR DESCRIPTION
Reduce maximum to 19, as everything bigger gets a 500 status:

This however only a partial fix, because the next request still gets a 500:

    http://connect.garmin.com/proxy/activity-search-service-1.2/json/activities?start=20&limit=19
    Traceback (most recent call last):
      File "./gcexport.py", line 285, in <module>
      ...
    urllib2.HTTPError: HTTP Error 500: Internal Server Error