### PR TITLE
Add more error handling

### DIFF
--- a/gcexport3.py
+++ b/gcexport3.py
@@ -472,23 +472,31 @@ activity...",
             URL_DEVICE_DETAIL
             + str(JSON_SUMMARY["metadataDTO"]["deviceApplicationInstallationId"])
         )
-        write_to_file(
-            ARGS.directory + "/" + str(a["activityId"]) + "_app_info.json",
-            DEVICE_DETAIL.decode(),
-            "a",
-        )
-        JSON_DEVICE = json.loads(DEVICE_DETAIL)
-        # print(JSON_DEVICE)
+        if DEVICE_DETAIL:
+            write_to_file(
+                ARGS.directory + "/" + str(a["activityId"]) + "_app_info.json",
+                DEVICE_DETAIL.decode(),
+                "a",
+            )
+            JSON_DEVICE = json.loads(DEVICE_DETAIL)
+            # print(JSON_DEVICE)
+        else:
+            print("Retrieving Device Details failed.")
+            JSON_DEVICE = None
 
         print("Activity details URL: " + URL_GC_ACTIVITY_DETAIL + str(a["activityId"]))
-        ACTIVITY_DETAIL = http_req(URL_GC_ACTIVITY_DETAIL + str(a["activityId"]))
-        write_to_file(
-            ARGS.directory + "/" + str(a["activityId"]) + "_activity_detail.json",
-            ACTIVITY_DETAIL.decode(),
-            "a",
-        )
-        JSON_DETAIL = json.loads(ACTIVITY_DETAIL)
-        # print(JSON_DETAIL)
+        try:
+            ACTIVITY_DETAIL = http_req(URL_GC_ACTIVITY_DETAIL + str(a["activityId"]))
+            write_to_file(
+                ARGS.directory + "/" + str(a["activityId"]) + "_activity_detail.json",
+                ACTIVITY_DETAIL.decode(),
+                "a",
+            )
+            JSON_DETAIL = json.loads(ACTIVITY_DETAIL)
+            # print(JSON_DETAIL)
+        except:
+            print("Retrieving Activity Details failed.")
+            JSON_DETAIL = None
 
         # Write stats to CSV.
         empty_record = ","
@@ -496,7 +504,7 @@ activity...",
 
         csv_record += (
             empty_record
-            if "activityName" not in a
+            if "activityName" not in a or not a["activityName"]
             else '"' + a["activityName"].replace('"', '""') + '",'
         )
 
@@ -628,7 +636,7 @@ activity...",
         )
         csv_record += (
             empty_record
-            if "productDisplayName" not in JSON_DEVICE
+            if not JSON_DEVICE or "productDisplayName" not in JSON_DEVICE
             else JSON_DEVICE["productDisplayName"]
             + " "
             + JSON_DEVICE["versionString"]
@@ -691,7 +699,7 @@ activity...",
         )
         csv_record += (
             empty_record
-            if "metricsCount"
+            if not JSON_DETAIL or "metricsCount"
             not in JSON_DETAIL["com.garmin.activity.details.json.ActivityDetails"]
             else str(
                 JSON_DETAIL["com.garmin.activity.details.json.ActivityDetails"][


### PR DESCRIPTION
- when DEVICE_DETAIL is empty/None
- when ACTIVITY_DETAIL gets HTTP error 500
- when a['activityName'] is None

This should also eliminate the problem of #11.

Error output for the missing DEVICE_DETAIL:

    Garmin Connect activity: [2487420533] Some Running
    https://connect.garmin.com/modern/proxy/download-service/export/gpx/activity/2487420533?full=true
        Downloading file... Activity summary URL: https://connect.garmin.com/modern/proxy/activity-service/activity/2487420533
    Device detail URL: https://connect.garmin.com/modern/proxy/device-service/deviceservice/app-info/799988
    Writing empty file since there was no GPX activity data...
    Traceback (most recent call last):
      File "./gcexport3.py", line 477, in <module>
        DEVICE_DETAIL.decode(),
    AttributeError: 'str' object has no attribute 'decode'

Error Output for HTTP error 500 for ACTIVITY_DETAIL:

    Garmin Connect activity: [2693805666] Some Running
    https://connect.garmin.com/modern/proxy/download-service/export/gpx/activity/2693805666?full=true
        Downloading file... Activity summary URL: https://connect.garmin.com/modern/proxy/activity-service/activity/2693805666
    Device detail URL: https://connect.garmin.com/modern/proxy/device-service/deviceservice/app-info/845288
    Activity details URL: https://connect.garmin.com/modern/proxy/activity-service-1.3/json/activityDetails/2693805666
    Traceback (most recent call last):
      File "./gcexport3.py", line 484, in <module>
        ACTIVITY_DETAIL = http_req(URL_GC_ACTIVITY_DETAIL + str(a["activityId"]))
      File "./gcexport3.py", line 151, in http_req
        response = OPENER.open((request), data=post)
      File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 531, in open
        response = meth(req, response)
      File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 641, in http_response
        'http', request, response, code, msg, hdrs)
      File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 569, in error
        return self._call_chain(*args)
      File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 503, in _call_chain
        result = func(*args)
      File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 649, in http_error_default
        raise HTTPError(req.full_url, code, msg, hdrs, fp)
    urllib.error.HTTPError: HTTP Error 500: Internal Server Error

Error Output for missing ActivityName:

    Garmin Connect activity: [630980785] None
    https://connect.garmin.com/modern/proxy/download-service/export/gpx/activity/630980785?full=true
        Downloading file... Activity summary URL: https://connect.garmin.com/modern/proxy/activity-service/activity/630980785
    Device detail URL: https://connect.garmin.com/modern/proxy/device-service/deviceservice/app-info/720039
    Activity details URL: https://connect.garmin.com/modern/proxy/activity-service-1.3/json/activityDetails/630980785
    Traceback (most recent call last):
      File "./gcexport3.py", line 508, in <module>
        else '"' + a["activityName"].replace('"', '""') + '",'
    AttributeError: 'NoneType' object has no attribute 'replace'
