### PR TITLE
fix `None` error

### DIFF
--- a/gcexport3.py
+++ b/gcexport3.py
@@ -505,7 +505,7 @@ activity...",
 
         csv_record += (
             empty_record
-            if "activityName" not in a
+            if "activityName" not in a or a["activityName"] is None
             else '"' + a["activityName"].replace('"', '""') + '",'
         )
 


### PR DESCRIPTION
it seems that sometimes activity records can contain the field `activityName` but with the value `None`. In this case the `.replace` call breaks.