### PR TITLE
Fix checking of files existence for --original arg

### DIFF
--- a/gcexport3.py
+++ b/gcexport3.py
@@ -415,7 +415,7 @@ while TOTAL_DOWNLOADED < TOTAL_TO_DOWNLOAD:
             data_filename = (
                 ARGS.directory + "/" + str(a["activityId"]) + "_activity.zip"
             )
-            fit_filename = ARGS.directory + "/" + str(a["activityId"]) + "_activity.fit"
+            fit_filename = ARGS.directory + "/" + str(a["activityId"]) + ".fit"
             download_url = URL_GC_ORIGINAL_ACTIVITY + str(a["activityId"])
             file_mode = "wb"
         else:


### PR DESCRIPTION
Garmin original FIT files don't contain activity suffix. Another option is to rename files but I don't think it makes sense (as a default behaviour at least).