### PR TITLE
improved regex PATTERN to find displayName

### DIFF
--- a/gcexport3.py
+++ b/gcexport3.py
@@ -324,7 +324,7 @@ if ARGS.count == "all":
     # extract the display name from the profile page, it should be in there as
     # \"displayName\":\"eschep\"
     PATTERN = re.compile(
-        r".*\\\"displayName\\\":\\\"([-.\w]+)\\\".*", re.MULTILINE | re.DOTALL
+        r'.*"displayName":"([-.\w]+)".*', re.MULTILINE | re.DOTALL
     )
     MATCH = PATTERN.match(PROFILE_PAGE)
     if not MATCH:


### PR DESCRIPTION
In my current configuration the regex did not work anymore to find the displayName to calculate the 'all' expression. This change helped me and now it is working again for me.
Using latest python3.9...