### PR TITLE
Add Docker support and update README with Docker usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.gitignore
+__pycache__/
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+WORKDIR /data
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+COPY gcexport3.py /usr/local/bin/gcexport3.py
+RUN chmod +x /usr/local/bin/gcexport3.py
+ENTRYPOINT ["/usr/local/bin/gcexport3.py"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -94,3 +94,13 @@ License
 Thank You
 ---------
 Thanks for using this script and I hope you find it as useful as I do! :smile:
+
+Docker Container
+----------------
+
+You can run this tool in Docker. After building the image, mount a host directory for data output and run:
+
+```bash
+docker build -t garmin-connect-export .
+docker run --rm -it -v "$(pwd):/data" garmin-connect-export --count all
+```

--- a/gcexport3.py
+++ b/gcexport3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.13
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """File: gcexport.py.


### PR DESCRIPTION
## Add Docker support, update README, and normalize shebang

**Summary**
This PR equips `garmin-connect-export` with first-class Docker support and tidies up the shebang line for consistency. In particular, it:

- Introduces a `Dockerfile` and accompanying `.dockerignore` so users can run the tool in a container without having to manage a local Python environment.
- Updates **README.md** with a new **“Docker Container”** section explaining how to build and run the image.
- Normalizes the script’s shebang to `#!/usr/bin/env python3` for better cross-platform portability.

---

### What’s changed

| File                | Changes                                                    |
|:--------------------|:-----------------------------------------------------------|
| **Dockerfile**      | New file – defines a minimal Python 3.12-slim image, installs requirements, and makes `gcexport3.py` executable. |
| **.dockerignore**   | New file – ignores VCS, `__pycache__`, compiled Python files. |
| **README.md**       | Adds a **“Docker Container”** section with build & run instructions. |
| **gcexport3.py**    | Shebang updated to `#!/usr/bin/env python3`.                |

---

### Motivation

Running in Docker provides a quick, reproducible environment:

- No need to install Python or dependencies locally
- Guarantees the same environment across platforms
- Simplifies CI-style automation or one-off exports on systems without Python

Normalizing the shebang to `env python3` also ensures the script picks up whichever Python 3 interpreter is on the user’s `$PATH`, making it more portable.

---

### Usage

After merging, users will be able to build and run the container as follows (see the updated README):

```bash
docker build -t garmin-connect-export .
docker run --rm -it -v "$(pwd):/data" garmin-connect-export --count all
```

---

### Testing

I have verified that:

1. The Docker image builds successfully (`docker build -t garmin-connect-export .`).
2. Running the container (`docker run --rm -it -v "$(pwd):/data" garmin-connect-export --help`) shows the expected help text.
3. A real export via `--count all` runs end-to-end inside the container and produces the expected output files.

---

Thanks for considering this enhancement! Looking forward to feedback.